### PR TITLE
radare2 calling convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Retrieve radare2 related information
 R2_PLUGIN_PATH=$(HOME)/.local/share/radare2/plugins/
 R2_INCLUDES_PATH=$(shell r2 -hh|grep INCDIR|awk '{print $$2}')
-R2_CFLAGS=-g -fPIC $(shell pkg-config --cflags r_asm)
+R2_CFLAGS=-g -fPIC $(shell pkg-config --cflags r_asm r_anal)
 
 # Retrieve Python related information
 PYTHON2_CFLAGS=$(shell python2-config --cflags)
@@ -11,7 +11,7 @@ PYTHON2_LDFLAGS=$(shell python2-config --ldflags)
 
 # Prepare r2m2 specific variables
 SO_EXT=$(shell uname|grep -q Darwin && echo dylib || echo so)
-R2M2_LDFLAGS=-shared $(PYTHON2_LDFLAGS) $(shell pkg-config --libs r_asm)
+R2M2_LDFLAGS=-shared $(PYTHON2_LDFLAGS) $(shell pkg-config --libs r_asm r_anal)
 R2M2_LIBS=r2m2_ad.$(SO_EXT) r2m2_Ae.$(SO_EXT)
 
 # OS detection

--- a/test/r2m2-cc.txt
+++ b/test/r2m2-cc.txt
@@ -1,0 +1,8 @@
+default.cc=r2m2
+r2m2=cc
+cc.r2m2.name=r2m2
+cc.r2m2.arg1=r1
+cc.r2m2.arg2=r2
+cc.r2m2.arg3=r3
+cc.r2m2.argn=stack
+cc.r2m2.ret=r0

--- a/test/r2m2.bats
+++ b/test/r2m2.bats
@@ -134,7 +134,7 @@
   rasm2 -a r2m2 "BL 0x8" -B > binary
 
   # Call r2
-  result=$(r2 -a r2m2 -m 0x2800 -qc 'af+ 0x2808 1 function_ut; pd 1' -e asm.emu=true binary)
-  [[ $result != *"BL         function_ut"* ]]
-  [[ $result != *"pc\=0x2808"* ]]
+  result=$(r2 -a r2m2 -m 0x2800 -qc 'af+ 0x2808 function_ut; pd 1' -e asm.emu=true binary)
+  [[ $result == *"function_ut"* ]]
+  [[ $result == *"pc=0x2808"* ]]
 }


### PR DESCRIPTION
This PR aims to dynamically provide a r2 calling convention database. 


### Database example
 ```
cat r2m2-cc.txt
default.cc=r2m2

r2m2=cc
cc.r2m2.name=r2m2
cc.r2m2.arg1=r1
cc.r2m2.arg2=r2
cc.r2m2.arg3=r3
cc.r2m2.argn=stack
cc.r2m2.ret=r0
```

### Building the database

```
cat r2m2-cc.txt |./shlr/sdb/sdb r2m2-cc.sdb -
```

### Accessing the database

```
./shlr/sdb/sdb r2m2-cc.sdb cc.r2m2.name
r2m2
```

### Going further

The following code can be used to impove this PR and build the database dynamically, for example using Sybil:
```
        char filename[] = "test.sdb";
        Sdb *s = NULL;
        s = sdb_new (NULL, filename, 0);
        sdb_disk_create (s);

        char key[] = "r2m2";
        char value[] = "cc";
        sdb_disk_insert (s, &key, &value);

        sdb_disk_finish (s);
        sdb_free (s);
```