### PR TITLE
Performances improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ r2m2$ docker run --rm -it -e 'R2M2_ARCH=x86_64' guedou/r2m2
 
 The following softwares must be installed:
 
-1. radare2
+1. radare2 (>= 2.6.0)
 
 2. miasm2
 

--- a/src/r2m2_Ae_cffi.py
+++ b/src/r2m2_Ae_cffi.py
@@ -29,6 +29,7 @@ def alloc_string(string):
     return ptr
 
 
+MIASM_MACHINE = None
 def miasm_machine():
     """Retrieve a miasm2 machine using the R2M2_ARCH environment variable."""
 
@@ -40,8 +41,13 @@ def miasm_machine():
         message += ", ".join(available_archs)
         print >> sys.stderr, message + "\n"
 
+        return None
+
     else:
-        return Machine(r2m2_arch)
+        global MIASM_MACHINE
+        if MIASM_MACHINE is None:
+            MIASM_MACHINE = Machine(r2m2_arch)
+        return MIASM_MACHINE
 
 
 def m2op_to_r2cond(m2_op):

--- a/src/r2m2_Ae_cffi.py
+++ b/src/r2m2_Ae_cffi.py
@@ -7,7 +7,6 @@ r2m2 plugin that uses miasm2 as a radare2 analysis and emulation backend
 
 import os
 import sys
-from collections import namedtuple
 
 from miasm2.analysis.machine import Machine
 from miasm2.expression.expression import ExprInt, ExprAff, ExprId, ExprCond, ExprOp, ExprMem, ExprCompose, ExprSlice, ExprLoc
@@ -30,7 +29,6 @@ class CachedRAnalOp(object):
     esil_string = None
     jump = None
     fail = None
-
 
     def fill_ranalop(self, r2_op):
         """
@@ -75,6 +73,8 @@ def alloc_string(string):
 
 
 MIASM_MACHINE = None
+
+
 def miasm_machine():
     """Retrieve a miasm2 machine using the R2M2_ARCH environment variable."""
 
@@ -162,7 +162,7 @@ def miasm_anal(r2_op, r2_address, r2_buffer, r2_length):
     # Return the cached result if any
     global LRU_CACHE
     result = LRU_CACHE.get(r2_address, None)
-    if not result is None:
+    if result is not None:
         result.fill_ranalop(r2_op)
         return
 
@@ -202,7 +202,7 @@ def miasm_anal(r2_op, r2_address, r2_buffer, r2_length):
     # Convert miasm expressions to ESIL
     get_esil(result, instr, loc_db)
 
-    ### Architecture agnostic analysis
+    # # # Architecture agnostic analysis
 
     # Instructions that *DO NOT* stop a basic bloc
     if instr.breakflow() is False:
@@ -329,7 +329,8 @@ def get_esil(analop, instruction, loc_db):
 def m2_filter_IRDst(ir_list):
     """Filter IRDst from the expessions list"""
 
-    return [ir for ir in ir_list if not (isinstance(ir, ExprAff) and isinstance(ir.dst, ExprId) and ir.dst.name == "IRDst")]
+    return [ir for ir in ir_list if not (isinstance(ir, ExprAff) and
+            isinstance(ir.dst, ExprId) and ir.dst.name == "IRDst")]
 
 
 def m2instruction_to_r2esil(instruction, loc_db):

--- a/src/r2m2_ad_cffi.py
+++ b/src/r2m2_ad_cffi.py
@@ -16,6 +16,8 @@ from miasm_embedded_r2m2_ad import ffi
 
 
 MIASM_MACHINE = None
+
+
 def miasm_machine():
     """Retrieve a miasm2 machine using the R2M2_ARCH environment variable."""
 

--- a/src/r2m2_ad_cffi.py
+++ b/src/r2m2_ad_cffi.py
@@ -15,6 +15,7 @@ from miasm2.expression.expression import ExprInt, ExprLoc
 from miasm_embedded_r2m2_ad import ffi
 
 
+MIASM_MACHINE = None
 def miasm_machine():
     """Retrieve a miasm2 machine using the R2M2_ARCH environment variable."""
 
@@ -28,7 +29,11 @@ def miasm_machine():
 
         return None
 
-    return Machine(r2m2_arch)
+    else:
+        global MIASM_MACHINE
+        if MIASM_MACHINE is None:
+            MIASM_MACHINE = Machine(r2m2_arch)
+        return MIASM_MACHINE
 
 
 @ffi.def_extern()

--- a/tools/cffi_miasm.py
+++ b/tools/cffi_miasm.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python2
-# Copyright (C) 2017 Guillaume Valadon <guillaume@valadon.net>
+# Copyright (C) 2018 Guillaume Valadon <guillaume@valadon.net>
 
 """
 Generate the miasm embedded library
 """
 
-import sys
 import cffi
 import argparse
 
@@ -41,6 +40,6 @@ ffi.embedding_init_code("".join(open("src/%s_cffi.py" % args.plugin_name).readli
 
 # Compile the library, or dump the C code
 if not args.compile:
-  ffi.emit_c_code("miasm_embedded_%s.c" % args.plugin_name)
+    ffi.emit_c_code("miasm_embedded_%s.c" % args.plugin_name)
 else:
-  ffi.compile(verbose=True)
+    ffi.compile(verbose=True)


### PR DESCRIPTION
This PR adds caching in order to improve performances. It fixes #30.

After:
```
$ time r2 -a r2m2 binary  -qc "s 0x10120; e asm.emu=1; pd 8192" > /dev/null

real    0m6.291s
user    0m6.196s
sys     0m0.092s
```

Before:
```
$ time r2 -a r2m2 binary -qc "s 0x10120; e asm.emu=1; pd 8192" > /dev/null

real    0m12.420s
user    0m12.332s
sys     0m0.084s
```